### PR TITLE
Longhorn Disk Refactor

### DIFF
--- a/docs/terraform-debugging.md
+++ b/docs/terraform-debugging.md
@@ -1,0 +1,125 @@
+## 1. Verify Terraform / libvirt side  
+1. **Confirm the libvirt volume was created**  
+   ```bash
+   terraform state list | grep longhorn_disks
+   # you should see something like
+   # libvirt_volume.longhorn_disks["telos-kube-vm-worker-node4"]
+   ```
+2. **Check the pool and volume on the host**  
+   ```bash
+   virsh pool-list             # should list your longhorn_pools (e.g. telos_longhorn_node4)
+   virsh vol-list <pool-name>  # e.g. virsh vol-list telos_longhorn_node4
+   # ensure telos-longhorn-node4.qcow2 appears with the correct size
+   ```
+3. **Inspect the domain XML**  
+   ```bash
+   virsh dumpxml telos-kube-vm-worker-node4 | xmllint --format -
+   ```
+   - Under `<devices>…<disk>` you should see your qcow2 volume attached as a virtio disk.
+
+If any of the above is missing, re-run `terraform apply` (or target the volume and domain) until the disk appears.
+
+---
+
+## 2. Inside the new VM  
+Once you’ve confirmed libvirt is serving the disk, SSH in:
+
+```bash
+ssh ubuntu@192.168.14.<node4_ip>
+```
+
+### a) List block devices  
+```bash
+lsblk -nd -o NAME,SIZE,MODEL
+```
+- You should see a device (e.g. `vdb` or `nvme1n1`) matching your `longhorn_disk_size` (e.g. ~222G or whatever you set).  
+- If it’s missing, libvirt didn’t attach it.
+
+### b) Inspect dmesg for disk events  
+```bash
+dmesg | tail -n 30
+```
+- Look for “virtio-blk virtioX:…” or new disk registration messages.
+- Any errors (I/O, device offline) will show here.
+
+### c) Check cloud-init logs  
+```bash
+sudo cat /var/log/cloud-init-output.log | grep -i longhorn -A5
+```
+- This is where your `mkfs.ext4` and fstab lines run.
+- Verify that `${longhorn_disk_size}` was correctly substituted (not blank or zero).
+- Look for errors like “No such device” or “mkfs: command not found.”
+
+---
+
+## 3. Validate fstab & mount  
+```bash
+grep longhorn /etc/fstab
+# you should see something like:
+/dev/vdb  /var/lib/longhorn  ext4  defaults  0 0
+```
+If it’s missing or malformed, cloud-init didn’t append it.
+
+Then:
+
+```bash
+sudo mount -a
+mount | grep /var/lib/longhorn
+```
+- If the mount fails, note the error and correct the device name in `/etc/fstab`.
+
+---
+
+## 4. Manual attach & format (if automation failed)  
+If you need a quick workaround while you debug cloud-init:
+
+1. **Identify the disk**  
+   ```bash
+   sudo lsblk
+   ```
+2. **Format**  
+   ```bash
+   sudo mkfs.ext4 -F /dev/vdb   # replace vdb with your disk
+   ```
+3. **Create mountpoint & mount**  
+   ```bash
+   sudo mkdir -p /var/lib/longhorn
+   echo "/dev/vdb /var/lib/longhorn ext4 defaults 0 0" | sudo tee -a /etc/fstab
+   sudo mount -a
+   ```
+4. **Restart K3s agent** (to re-trigger the `--node-label=node.longhorn.io/create-default-disk=true` logic)  
+   ```bash
+   sudo systemctl restart k3s-agent
+   ```
+
+---
+
+## 5. Check Kubernetes & Longhorn  
+1. **Ensure the node has the Longhorn label**  
+   ```bash
+   kubectl get node telos-kube-vm-worker-node4 --show-labels
+   ```
+   - Look for `node.longhorn.io/create-default-disk=true`.  
+   - If missing, add it:
+     ```bash
+     kubectl label node telos-kube-vm-worker-node4 node.longhorn.io/create-default-disk=true
+     ```
+2. **Inspect Longhorn’s UI / CRDs**  
+   ```bash
+   # in the longhorn namespace:
+   kubectl -n longhorn-system get nodes.longhorn.io
+   kubectl -n longhorn-system describe nodes.longhorn.io telos-kube-vm-worker-node4
+   ```
+   - You should see the “Storage Available” pool under that node.
+3. **Trigger default disk creation**  
+   - In the Longhorn UI → **Settings** → “Automatically create default disk” should be on.  
+   - Or, in each node’s CR, under `.spec.disks`, you can manually add a disk entry pointing to `/var/lib/longhorn`.
+
+---
+
+### Summary
+1. **Host-level**: confirm Terraform/libvirt actually made & attached the new qcow2.  
+2. **VM-level**: check `lsblk`, cloud-init logs, dmesg, fstab, and either fix cloud-init or manually format & mount.  
+3. **K8s-level**: ensure the node label is set so Longhorn picks up `/var/lib/longhorn` as a storage disk.
+
+Work through these in order, and you’ll quickly see whether the problem is in Terraform, cloud-init, or the K3s/Longhorn layer. Let me know which step uncovers the culprit!

--- a/scripts/utils/patch-longhorn-tags.sh
+++ b/scripts/utils/patch-longhorn-tags.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="longhorn-system"
+LABEL_KEY="longhorn-true"
+MAX_ATTEMPTS=25
+SLEEP_INTERVAL=5
+
+echo "🔍 Verifying nodes with label $LABEL_KEY..."
+nodes=$(kubectl get nodes -l $LABEL_KEY -o name)
+
+if [[ -z "$nodes" ]]; then
+  echo "⚠️  No nodes found with label '$LABEL_KEY'."
+  echo "   Check: kubectl get nodes --show-labels"
+  exit 1
+fi
+
+echo "📋 Nodes to process:"
+echo "$nodes"
+echo
+
+echo "🔖 Patching Kubernetes node annotations (longhorn.io/node-tags)..."
+echo "$nodes" | while read -r node; do
+  echo "  → Annotating $node ..."
+  kubectl patch "$node" \
+    --type=merge \
+    -p '{"metadata": {"annotations": {"longhorn.io/node-tags": "[\"longhorn-true\"]"}}}'
+done
+
+echo
+echo "🏷️  Patching Longhorn CRD nodes (.spec.tags)…"
+echo "$nodes" | sed 's|^node/||' | while read -r node; do
+  echo "  → CRD node: $node"
+
+  for i in $(seq 1 $MAX_ATTEMPTS); do
+    status=$(kubectl get -n $NAMESPACE nodes.longhorn.io "$node" \
+      -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    if [[ "$status" != "True" ]]; then
+      echo "     ⏳ Not Ready ($status). retry $i/$MAX_ATTEMPTS…"
+      sleep $SLEEP_INTERVAL
+      continue
+    fi
+
+    echo "     ✅ Ready! Patching tags…"
+    kubectl patch -n $NAMESPACE nodes.longhorn.io "$node" \
+      --type=merge \
+      -p '{"spec": {"tags": ["longhorn-true"]}}'
+    echo "     ✔️  Patched .spec.tags for $node"
+    break
+  done
+done
+
+echo
+echo "🎉 Done patching Longhorn annotations & tags."

--- a/terraform/config/cloud_init.cfg
+++ b/terraform/config/cloud_init.cfg
@@ -51,36 +51,51 @@ runcmd:
 
   # Ensure ssh key is owned by ubuntu user
   - chown ubuntu:ubuntu /home/ubuntu/.ssh
-
   - chown ubuntu:ubuntu /home/ubuntu/.ssh/id_rsa
   - chmod 700 /home/ubuntu/.ssh
   - chmod 600 /home/ubuntu/.ssh/id_rsa
 
   # Install K3s Control Plane
-  - if [ "${node_type}" = "control-plane" ]; then
-      curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--disable traefik --tls-san ${k3s_domain} --node-taint node-role.kubernetes.io/control-plane:NoSchedule --node-label role=control-plane" sh -;
+  - |
+    if [ "${node_type}" = "control-plane" ]; then
+      curl -sfL https://get.k3s.io \
+        | INSTALL_K3S_EXEC="--disable traefik \
+                            --tls-san ${k3s_domain} \
+                            --node-taint node-role.kubernetes.io/control-plane:NoSchedule \
+                            --node-label role=control-plane" sh -;
       export K3S_TOKEN=$(sudo cat /var/lib/rancher/k3s/server/node-token);
       echo "$K3S_TOKEN" | tee /home/ubuntu/k3s_token;
       chown ubuntu:ubuntu /home/ubuntu/k3s_token;
     fi
 
-  # Format longhorn volume (Worker Nodes)
-  - if [ "${node_type}" = "worker-node" ]; then
-      echo "Setting up Longhorn Disk...";
-      echo "${longhorn_disk_size}";
-      LONGHORN_DISK=$(lsblk -nd --output NAME,SIZE | grep "${longhorn_disk_size}G" | awk '{print $1}');
+  # Format longhorn volume (Worker Nodes) using byte-exact size
+  - |
+    if [ "${node_type}" = "worker-node" ]; then
+      echo "Setting up Longhorn Disk by byte count…";
+
+      # calculate target size in bytes
+      TARGET_BYTES=$(( ${longhorn_disk_size} * 1024 * 1024 * 1024 ));
+      echo "Expecting disk of $TARGET_BYTES bytes";
+
+      # find device whose size exactly matches
+      LONGHORN_DISK=$(lsblk -nd --output NAME,SIZE --bytes \
+        | awk -v want="$TARGET_BYTES" '$2 == want { print $1 }');
+
       if [ -n "$LONGHORN_DISK" ]; then
         mkfs.ext4 -F "/dev/$LONGHORN_DISK";
         mkdir -p /var/lib/longhorn;
-        echo "/dev/$LONGHORN_DISK /var/lib/longhorn ext4 defaults 0 0" | tee -a /etc/fstab;
+        echo "/dev/$LONGHORN_DISK /var/lib/longhorn ext4 defaults 0 0" \
+          | tee -a /etc/fstab;
         mount -a;
       else
-        echo "No 1TB disk found!";
+        echo "ERROR: no disk of size ${longhorn_disk_size}G ($TARGET_BYTES bytes) found!";
+        lsblk -nd --output NAME,SIZE --bytes;
       fi
     fi
 
   # Install K3s Agent (Worker Nodes)
-  - if [ "${node_type}" = "worker-node" ]; then
+  - |
+    if [ "${node_type}" = "worker-node" ]; then
       while ! curl -k https://${control_ip}:6443 >/dev/null 2>&1; do
         echo "Waiting for control plane...";
         sleep 5;
@@ -89,8 +104,13 @@ runcmd:
       sleep 20;
 
       ls -la /home/ubuntu/.ssh;
-      export K3S_TOKEN=$(ssh -o "StrictHostKeyChecking=no" -i /home/ubuntu/.ssh/id_rsa ubuntu@${control_ip} "cat /home/ubuntu/k3s_token");
+      export K3S_TOKEN=$(ssh -o "StrictHostKeyChecking=no" \
+        -i /home/ubuntu/.ssh/id_rsa ubuntu@${control_ip} "cat /home/ubuntu/k3s_token");
       echo "K3S_TOKEN:";
       echo $K3S_TOKEN;
-      curl -sfL https://get.k3s.io | K3S_URL="https://${control_ip}:6443" K3S_TOKEN="$K3S_TOKEN" INSTALL_K3S_EXEC="--node-label longhorn-true --node-label node.longhorn.io/create-default-disk=true" sh -;
+      curl -sfL https://get.k3s.io \
+        | K3S_URL="https://${control_ip}:6443" \
+          K3S_TOKEN="$K3S_TOKEN" \
+          INSTALL_K3S_EXEC="--node-label longhorn-true \
+                            --node-label node.longhorn.io/create-default-disk=true" sh -;
     fi


### PR DESCRIPTION
This PR refactors our Longhorn disk provisioning to support arbitrary sizes and adds tooling and docs to streamline setup and debugging.

**What’s Changed**  
1. **`terraform/config/cloud_init.cfg`**  
   - Replaced the legacy human‐unit grep/awk logic with a **byte‐exact** lookup (`lsblk --bytes` + `awk`) to identify and format the correct Longhorn device.  
   - All other cloud-init steps remain identical to the proven, working version.  

2. **`scripts/utils/patch-longhorn-tags.sh`**  
   - New helper script that:  
     - Annotates every Kubernetes node labeled `longhorn-true` with `longhorn.io/node-tags`.  
     - Waits for the corresponding Longhorn CRD node to become Ready, then patches its `.spec.tags` to include `longhorn-true`.  
   - Fully idempotent and safe to re-run.

3. **`docs/terraform-debugging.md`**  
   - Brand-new guide covering:  
     - Verifying Terraform/libvirt side (pools, volumes, domain XML)  
     - Inspecting and formatting disks inside the VM  
     - Validating `fstab`, mounts, and cloud-init logs  
     - Checking Kubernetes labels and Longhorn CRDs  
   - A step-by-step reference for triaging disk-attachment issues.

**How to Test**  
1. **Disk provisioning**  
   - Destroy/recreate a worker node with a custom `longhorn_disk_size` in `terraform.tfvars`.  
   - Verify `/var/lib/longhorn` is formatted and mounted on the correct byte-sized device.  

2. **Tagging utility**  
   - Label some nodes `kubectl label node <node> longhorn-true`.  
   - Run `scripts/utils/patch-longhorn-tags.sh` and confirm both the K8s annotation and the Longhorn CRD tag appear.  

3. **Debug workflow**  
   - Follow the steps in `docs/terraform-debugging.md` to reproduce and resolve any disk-attachment failures.

**Impact**  
- **Non-breaking**: existing cloud-init flows and Terraform state remain intact until you opt to recreate VMs.  
- **Reliability**: ensures correct disk detection regardless of humanized unit display, and automates node tagging tasks.