### PR TITLE
updated cpu pass-through

### DIFF
--- a/scripts/config.template.sh
+++ b/scripts/config.template.sh
@@ -5,6 +5,7 @@ export SECRETS_PATH="./secrets"
 export MANIFESTS_PATH="./kubernetes/manifests"
 export MIDDLEWARES_PATH="./base/kubernetes/manifests/middlewares"
 export HELM_VALUES_PATH="./helm"
+export HELM_VOLUMES_RESTORE_VALUES_PATH="./helm/restores"
 export HELM_CHARTS_PATH="./base/helm-charts"
 
 # Default values for environment variables

--- a/terraform/config/memory_backing.xslt
+++ b/terraform/config/memory_backing.xslt
@@ -1,24 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
+<xsl:stylesheet 
+    version="1.0"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
   <xsl:output method="xml" indent="yes"/>
 
-  <!-- Match the root <domain> node -->
+  <!-- 1) Drop any existing <cpu> definitions entirely -->
+  <xsl:template match="cpu"/>
+
+  <!-- 2) Root template: copy the <domain> element and everything beneath… -->
   <xsl:template match="/domain">
     <xsl:copy>
+      <!-- …preserve ALL child nodes & attributes verbatim -->
       <xsl:apply-templates select="@*|node()"/>
-      <!-- Add memoryBacking section inside <domain> -->
+
+      <!-- 3) THEN append your passthrough CPU -->
+      <cpu mode="host-passthrough" check="none" migratable="on"/>
+
+      <!-- 4) AND append your memoryBacking block -->
       <memoryBacking>
-        <source type='memfd'/>
-        <access mode='shared'/>
+        <source type="memfd"/>
+        <access mode="shared"/>
       </memoryBacking>
     </xsl:copy>
   </xsl:template>
 
-  <!-- Identity transform (preserve all other XML content) -->
+  <!-- 5) Identity template for everything else -->
   <xsl:template match="@*|node()">
     <xsl:copy>
       <xsl:apply-templates select="@*|node()"/>
     </xsl:copy>
   </xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
---

### ✨ Enable CPU Passthrough and MemoryBacking for VMs

This PR updates the VM domain template logic to enable more efficient and native-like CPU behavior via passthrough, and prepares the VMs for better shared memory handling.

#### 🔧 Changes Introduced

* **Updated `memory_backing.xslt`**:

  * Removed any existing `<cpu>` definitions during XSL transformation.
  * Added a new `<cpu mode="host-passthrough" check="none" migratable="on"/>` block for better CPU compatibility.
  * Applied identity transform logic for all other unchanged elements to preserve original XML structure.

* **Updated `scripts/config.template.sh`**:

  * Added `HELM_VOLUMES_RESTORE_VALUES_PATH` to environment variable exports.

#### 📌 Motivation

This change allows VMs to use the host CPU more transparently and prepares the memory subsystem for shared-memory workloads, which is especially useful for performance testing or containerized environments requiring better host integration.

---
