### PR TITLE
Nextcloud fully deployed with OnlyOffice and DrawIO

### DIFF
--- a/docs/nextcloud-debugging-commands.md
+++ b/docs/nextcloud-debugging-commands.md
@@ -1,0 +1,100 @@
+---
+
+## ✅ OnlyOffice Integration Debug & Validation Guide
+
+This guide documents key `kubectl` and helper commands to validate and debug the OnlyOffice + Nextcloud setup in your K3s/Kubernetes environment.
+
+---
+
+### 🛠️ Validate JWT Environment in OnlyOffice Pods
+
+Check that the JWT-related environment variables are present and identical across all OnlyOffice containers:
+
+```bash
+# Docservice (primary backend)
+kubectl -n nextcloud exec deploy/docservice -c docservice -- env | grep JWT
+
+# Converter (document rendering)
+kubectl -n nextcloud exec deploy/converter -c converter -- env | grep JWT
+
+# Documentserver (sometimes a combined pod)
+kubectl -n nextcloud exec deploy/documentserver -c documentserver -- env | grep JWT
+```
+
+---
+
+### 🧪 Test HTTP Connectivity Between OnlyOffice and Nextcloud
+
+Ensure documentserver can reach Nextcloud via its public and internal URLs:
+
+```bash
+# From docservice pod
+kubectl -n nextcloud exec deploy/docservice -c docservice -- \
+  wget -qO- --no-check-certificate https://nextcloud.telos.company/status.php
+
+# Or using internal service URL
+kubectl -n nextcloud exec deploy/docservice -c docservice -- \
+  wget -qO- http://nextcloud:8080/status.php
+```
+
+---
+
+### ⚙️ Check OnlyOffice App Settings in Nextcloud
+
+Use `occ` to view and manage Nextcloud’s OnlyOffice app config:
+
+```bash
+# View current OnlyOffice config
+kubectl -n nextcloud exec deploy/nextcloud -c nextcloud -- \
+  su -s /bin/sh www-data -c 'php occ config:list onlyoffice'
+```
+
+Expected values (minimally):
+
+* `DocumentServerUrl`: `https://onlyoffice.telos.company`
+* `DocumentServerInternalUrl`: `http://documentserver`
+* `StorageUrl`: `http://nextcloud:8080`
+* `jwt_secret`: (secret value)
+* `verify_peer_off`: `"true"`
+* `jwt_enabled`: `"true"`
+
+---
+
+### ⚙️ Set or Fix Config with `occ`
+
+Minimal command set to configure OnlyOffice:
+
+```bash
+# Get JWT from Kubernetes secret
+JWT_SECRET=$(kubectl get secret onlyoffice-creds -n nextcloud -o jsonpath='{.data.JWT_SECRET}' | base64 --decode)
+
+# Apply config (adjust POD name if needed)
+POD=$(kubectl get pod -n nextcloud -l app.kubernetes.io/name=nextcloud -o jsonpath='{.items[0].metadata.name}')
+kubectl -n nextcloud exec "$POD" -c nextcloud -- su -s /bin/bash www-data -c \
+  "php occ config:app:set onlyoffice DocumentServerUrl --value='https://onlyoffice.telos.company'"
+kubectl -n nextcloud exec "$POD" -c nextcloud -- su -s /bin/bash www-data -c \
+  "php occ config:app:set onlyoffice DocumentServerInternalUrl --value='http://documentserver'"
+kubectl -n nextcloud exec "$POD" -c nextcloud -- su -s /bin/bash www-data -c \
+  "php occ config:app:set onlyoffice StorageUrl --value='http://nextcloud:8080'"
+kubectl -n nextcloud exec "$POD" -c nextcloud -- su -s /bin/bash www-data -c \
+  "php occ config:app:set onlyoffice jwt_secret --value='$JWT_SECRET'"
+kubectl -n nextcloud exec "$POD" -c nextcloud -- su -s /bin/bash www-data -c \
+  "php occ config:app:set onlyoffice verify_peer_off --value='true'"
+kubectl -n nextcloud exec "$POD" -c nextcloud -- su -s /bin/bash www-data -c \
+  "php occ config:app:set onlyoffice jwt_enabled --value='true'"
+```
+
+---
+
+### 🔁 Restart Pods (Optional)
+
+If needed, restart deployments to re-read secret values or config:
+
+```bash
+kubectl rollout restart deployment -n nextcloud docservice
+kubectl rollout restart deployment -n nextcloud converter
+kubectl rollout restart deployment -n nextcloud documentserver
+kubectl rollout restart deployment -n nextcloud nextcloud
+```
+
+---

--- a/helm-charts/onlyoffice/app/.helmignore
+++ b/helm-charts/onlyoffice/app/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/onlyoffice/app/Chart.yaml
+++ b/helm-charts/onlyoffice/app/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: onlyoffice
+description: OnlyOffice Docs with Redis & PostgreSQL dependencies
+type: application
+version: 0.1.0
+appVersion: "8.3.2"
+
+dependencies:
+  - name: docs
+    alias: onlyoffice
+    version: 4.6.0
+    repository: "https://download.onlyoffice.com/charts/stable"
+    condition: onlyoffice.enabled

--- a/helm-charts/onlyoffice/app/templates/certificate.yaml
+++ b/helm-charts/onlyoffice/app/templates/certificate.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.certificate.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.certificate.name | quote }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: {{ .Values.certificate.secretName | quote }}
+  issuerRef:
+    name: {{ .Values.certificate.issuer.name | quote }}
+    kind: {{ .Values.certificate.issuer.kind | quote }}
+  dnsNames:
+    {{- range .Values.certificate.dnsNames }}
+    - {{ . | quote }}
+    {{- end }}
+{{- end }}

--- a/helm-charts/onlyoffice/app/templates/ingressroute.yaml
+++ b/helm-charts/onlyoffice/app/templates/ingressroute.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.ingressroute.enabled }}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- range $key, $value := .Values.ingressroute.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: "Host(`{{ .Values.ingressroute.host }}`)"
+      kind: Rule
+      middlewares:
+        - name: onlyoffice-secure-headers
+          namespace: nextcloud
+      services:
+        - name: documentserver
+          port: {{ .Values.onlyoffice.service.port }}
+  tls:
+    secretName: {{ .Values.ingressroute.tls.secretName }}
+{{- end }}

--- a/helm-charts/onlyoffice/backend/.helmignore
+++ b/helm-charts/onlyoffice/backend/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/onlyoffice/backend/Chart.yaml
+++ b/helm-charts/onlyoffice/backend/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+name: onlyoffice-backend
+description: Redis & PostgreSQL dependencies
+type: application
+version: 0.1.0
+appVersion: "8.3.2"
+
+dependencies:
+  - name: postgresql
+    version: 15.5.0
+    repository: "oci://registry-1.docker.io/bitnamicharts"
+    condition: postgresql.enabled
+    tags:
+      - database
+
+  - name: redis
+    version: 19.6.4
+    repository: "oci://registry-1.docker.io/bitnamicharts"
+    condition: redis.enabled
+    tags:
+      - cache
+
+  - name: rabbitmq
+    version: 16.0.1
+    repository: "oci://registry-1.docker.io/bitnamicharts"
+    condition: rabbitmq.enabled
+    tags:
+      - messaging

--- a/helm-charts/onlyoffice/volumes/.helmignore
+++ b/helm-charts/onlyoffice/volumes/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/onlyoffice/volumes/Chart.yaml
+++ b/helm-charts/onlyoffice/volumes/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: onlyoffice-volumes
+description: A Helm chart for deploying OnlyOffice with PostgreSQL and Redis
+type: application
+version: 0.1.0
+appVersion: 29.0.0

--- a/helm-charts/onlyoffice/volumes/templates/volumes-files.yaml
+++ b/helm-charts/onlyoffice/volumes/templates/volumes-files.yaml
@@ -1,0 +1,56 @@
+{{- $volumeType := index .Values "onlyoffice-files" }}
+{{- if $volumeType.persistenceLonghorn.enabled }}
+
+{{/* Convert a size in Gi (e.g. "48Gi") to bytes */}}
+{{- $sizeStr := $volumeType.persistenceLonghorn.size | trimSuffix "Gi" }}
+{{- $sizeGi := $sizeStr | int }}
+{{- $sizeBytes := mul $sizeGi (mul 1024 (mul 1024 1024)) }}
+
+---
+apiVersion: longhorn.io/v1beta2
+kind: Volume
+metadata:
+  name: {{ $volumeType.persistenceLonghorn.pvName | quote }}
+  namespace: longhorn-system
+spec:
+  numberOfReplicas: {{ $volumeType.persistenceLonghorn.numberOfReplicas }}
+  frontend: {{ $volumeType.persistenceLonghorn.frontend | quote }}
+  backupTargetName: {{ $volumeType.persistenceLonghorn.backupTargetName | quote }}
+  size: "{{ $sizeBytes }}"
+  {{- if $volumeType.persistenceLonghorn.restore }}
+  fromBackup: {{ $volumeType.persistenceLonghorn.fromBackup | quote }}
+  {{- end }}
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $volumeType.persistenceLonghorn.pvcName | quote }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  accessModes:
+    - {{ $volumeType.persistenceLonghorn.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ $volumeType.persistenceLonghorn.size | quote }}
+  storageClassName: {{ $volumeType.persistenceLonghorn.storageClassName | quote }}
+  volumeName: {{ $volumeType.persistenceLonghorn.pvName | quote }}
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ $volumeType.persistenceLonghorn.pvName | quote }}
+spec:
+  capacity:
+    storage: {{ $volumeType.persistenceLonghorn.size | quote }}
+  volumeMode: Filesystem
+  accessModes:
+    - {{ $volumeType.persistenceLonghorn.accessMode | quote }}
+  persistentVolumeReclaimPolicy: {{ $volumeType.persistenceLonghorn.reclaimPolicy | quote }}
+  storageClassName: {{ $volumeType.persistenceLonghorn.storageClassName | quote }}
+  csi:
+    driver: {{ $volumeType.persistenceLonghorn.csiDriver | quote }}
+    volumeHandle: {{ $volumeType.persistenceLonghorn.pvName | quote }}
+
+{{- end }}

--- a/helm-charts/onlyoffice/volumes/templates/volumes-postgres.yaml
+++ b/helm-charts/onlyoffice/volumes/templates/volumes-postgres.yaml
@@ -1,0 +1,56 @@
+{{- $volumeType := index .Values "onlyoffice-postgres-db" }}
+{{- if $volumeType.persistenceLonghorn.enabled }}
+
+{{/* Convert a size in Gi (e.g. "48Gi") to bytes */}}
+{{- $sizeStr := $volumeType.persistenceLonghorn.size | trimSuffix "Gi" }}
+{{- $sizeGi := $sizeStr | int }}
+{{- $sizeBytes := mul $sizeGi (mul 1024 (mul 1024 1024)) }}
+
+---
+apiVersion: longhorn.io/v1beta2
+kind: Volume
+metadata:
+  name: {{ $volumeType.persistenceLonghorn.pvName | quote }}
+  namespace: longhorn-system
+spec:
+  numberOfReplicas: {{ $volumeType.persistenceLonghorn.numberOfReplicas }}
+  frontend: {{ $volumeType.persistenceLonghorn.frontend | quote }}
+  backupTargetName: {{ $volumeType.persistenceLonghorn.backupTargetName | quote }}
+  size: "{{ $sizeBytes }}"
+  {{- if $volumeType.persistenceLonghorn.restore }}
+  fromBackup: {{ $volumeType.persistenceLonghorn.fromBackup | quote }}
+  {{- end }}
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $volumeType.persistenceLonghorn.pvcName | quote }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  accessModes:
+    - {{ $volumeType.persistenceLonghorn.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ $volumeType.persistenceLonghorn.size | quote }}
+  storageClassName: {{ $volumeType.persistenceLonghorn.storageClassName | quote }}
+  volumeName: {{ $volumeType.persistenceLonghorn.pvName | quote }}
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ $volumeType.persistenceLonghorn.pvName | quote }}
+spec:
+  capacity:
+    storage: {{ $volumeType.persistenceLonghorn.size | quote }}
+  volumeMode: Filesystem
+  accessModes:
+    - {{ $volumeType.persistenceLonghorn.accessMode | quote }}
+  persistentVolumeReclaimPolicy: {{ $volumeType.persistenceLonghorn.reclaimPolicy | quote }}
+  storageClassName: {{ $volumeType.persistenceLonghorn.storageClassName | quote }}
+  csi:
+    driver: {{ $volumeType.persistenceLonghorn.csiDriver | quote }}
+    volumeHandle: {{ $volumeType.persistenceLonghorn.pvName | quote }}
+
+{{- end }}

--- a/helm-charts/onlyoffice/volumes/values.yaml
+++ b/helm-charts/onlyoffice/volumes/values.yaml
@@ -1,0 +1,31 @@
+onlyoffice-files:
+  persistenceLonghorn:
+    enabled: false
+    restore: false
+    pvcName: "onlyoffice-files-pvc"
+    pvName: "onlyoffice-files-pv"
+    size: "4Gi"
+    accessMode: "ReadWriteOnce"
+    reclaimPolicy: "Retain"
+    storageClassName: "longhorn"
+    csiDriver: "driver.longhorn.io"
+    numberOfReplicas: 3
+    frontend: blockdev
+    backupTargetName: default
+    fromBackup: "s3://exampleorg@minio.example.com/longhorn?backup=dummy_backup_id&volume=onlyoffice-files-pv"
+
+onlyoffice-postgres-db:
+  persistenceLonghorn:
+    enabled: false
+    restore: false
+    pvcName: "onlyoffice-postgres-db-pvc"
+    pvName: "onlyoffice-postgres-db-pv"
+    size: "1Gi"
+    accessMode: "ReadWriteOnce"
+    reclaimPolicy: "Retain"
+    storageClassName: "longhorn"
+    csiDriver: "driver.longhorn.io"
+    numberOfReplicas: 3
+    frontend: blockdev
+    backupTargetName: default
+    fromBackup: "s3://longhorn-backups@minio.example.com/longhorn?backup=dummy_backup_id&volume=onlyoffice-postgres-db-pv"

--- a/kubernetes/manifests/middlewares/onlyoffice-secure-headers.yaml
+++ b/kubernetes/manifests/middlewares/onlyoffice-secure-headers.yaml
@@ -1,0 +1,9 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: onlyoffice-secure-headers
+  namespace: nextcloud
+spec:
+  headers:
+    customRequestHeaders:
+      X-Forwarded-Proto: "https"

--- a/scripts/deployments/deploy-longhorn.sh
+++ b/scripts/deployments/deploy-longhorn.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+set -e  # Exit on error
+
+# Determine the script's directory and source the configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$SCRIPT_DIR/config.sh" ]; then
+  source "$SCRIPT_DIR/config.sh"
+else
+  # Fallback: Try to source config from the thin repo if available
+  if [ -f "$SCRIPT_DIR/../../../scripts/config.sh" ]; then
+    source "$SCRIPT_DIR/../../../scripts/config.sh"
+  else
+    echo "Missing config.sh file. Exiting."
+    exit 1
+  fi
+fi
+
+# Define paths to manifests
+LONGHORN_MANIFESTS_PATH="$MANIFESTS_PATH/longhorn"
+
+echo "Deploying Longhorn..."
+kubectl create namespace longhorn-system || true
+
+echo "Importing Longhorn auth key"
+kubectl apply -f "$SECRETS_PATH/longhorn-auth-sealed-secret.yaml"
+echo "Longhorn Auth Key Imported Successfully!"
+
+echo "Importing MinIO Credentials"
+kubectl apply -f "$SECRETS_PATH/minio-credentials-sealed-secret.yaml"
+echo "MinIO Credentials Imported Successfully!"
+
+echo "⌛ Waiting for at least one worker node with label longhorn-true to be Ready..."
+until kubectl get nodes -l longhorn-true -o jsonpath='{.items[0].status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | grep -q True; do
+  echo "No Ready node found with label 'longhorn-true'. Retrying in 5s..."
+  sleep 5
+done
+
+echo "✅ Found a Ready worker node labeled 'longhorn-true'. Proceeding with Longhorn install..."
+
+# Deploy Staging or Prod
+if [[ "$DEPLOYMENT_MODE" == "prod" ]]; then
+  echo "🚀 Deploying Production..."
+  VALUES_FILE="$HELM_VALUES_PATH/prod/longhorn-values.yaml"
+else
+  echo "⚠️  Deploying Staging..."
+  VALUES_FILE="$HELM_VALUES_PATH/staging/longhorn-values.yaml"
+fi
+
+helm dependency update "$HELM_CHARTS_PATH/longhorn"
+helm upgrade --install longhorn "$HELM_CHARTS_PATH/longhorn" \
+  --namespace longhorn-system \
+  --values "$VALUES_FILE"
+
+# Update local-path to not be default storage class
+kubectl patch storageclass local-path -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+
+echo "Waiting for Longhorn to be fully available..."
+kubectl wait --for=condition=available --timeout=300s deployment --all -n longhorn-system
+
+echo "Applying patch to disable scheduling on the control-plane node..."
+kubectl apply -f "$LONGHORN_MANIFESTS_PATH/disable-longhorn-scheduling.yaml"
+
+echo "Applying backup target settings..."
+kubectl apply -f "$LONGHORN_MANIFESTS_PATH/longhorn-settings.yaml"
+
+echo "Patching nodes with Longhorn tag..."
+kubectl get nodes -l longhorn-true -o name | while read node; do
+  echo "Patching $node..."
+  kubectl patch "$node" --type=merge -p '{"metadata": {"annotations": {"longhorn.io/node-tags": "[\"longhorn-true\"]"}}}'
+done
+
+for node in $(kubectl get nodes -l longhorn-true -o name | awk -F'/' '{print $2}'); do
+  echo "Tagging Longhorn node: $node..."
+
+  for attempt in {1..25}; do
+    # Check if the Longhorn node is ready by querying its Ready condition
+    node_ready=$(kubectl get -n longhorn-system nodes.longhorn.io "$node" -o jsonpath="{.status.conditions[?(@.type=='Ready')].status}")
+    
+    if [ "$node_ready" != "True" ]; then
+      echo "⏳ Node $node is not ready (Ready status: $node_ready). Retrying in 5 seconds (attempt $attempt/10)..."
+      sleep 5
+      continue
+    fi
+
+    # If node is ready, attempt to patch the node with the Longhorn tag
+    if kubectl patch -n longhorn-system nodes.longhorn.io "$node" \
+      --type=merge \
+      -p '{"spec": {"tags": ["longhorn-true"]}}'; then
+      echo "✔️  Tagged $node successfully."
+      break
+    else
+      echo "⏳ Patch for node $node failed. Retrying in 5 seconds (attempt $attempt/10)..."
+      sleep 5
+    fi
+  done
+done
+
+echo "Longhorn node tags applied."
+
+echo "✅ Longhorn deployment completed successfully!"
+
+echo "🎉 Longhorn deployed!"

--- a/scripts/deployments/deploy-monitoring.sh
+++ b/scripts/deployments/deploy-monitoring.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e  # Exit on error
+
+# Determine the script's directory and source the configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$SCRIPT_DIR/config.sh" ]; then
+  source "$SCRIPT_DIR/config.sh"
+else
+  # Fallback: Try to source config from the thin repo if available
+  if [ -f "$SCRIPT_DIR/../../../scripts/config.sh" ]; then
+    source "$SCRIPT_DIR/../../../scripts/config.sh"
+  else
+    echo "Missing config.sh file. Exiting."
+    exit 1
+  fi
+fi
+
+echo "📡 Deploying Monitoring Stack..."
+
+# Create Namespace
+kubectl create namespace monitoring || true
+
+echo "🔐 Restoring Data Volume..."
+base/scripts//longhorn-automation.sh restore grafana
+echo "✅ Persistent Data Volume Restored!"
+
+echo "🔑 Import Grafana Secrets..."
+kubectl apply -f "$SECRETS_PATH/grafana-admin-credentials-sealed-secret.yaml"
+
+# Deploy Prometheus
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+helm upgrade --install prometheus prometheus-community/kube-prometheus-stack \
+  --namespace monitoring \
+  --values "$HELM_VALUES_PATH/prometheus-values.yaml"
+
+# Deploy Staging or Prod
+if [[ "$DEPLOYMENT_MODE" == "prod" ]]; then
+  echo "🚀 Deploying Production..."
+  VALUES_FILE="$HELM_VALUES_PATH/prod/grafana-values.yaml"
+else
+  echo "⚠️  Deploying Staging..."
+  VALUES_FILE="$HELM_VALUES_PATH/staging/grafana-values.yaml"
+fi
+
+# Deploy Grafana
+helm dependency update "$HELM_CHARTS_PATH/monitoring/grafana"
+helm upgrade --install grafana "$HELM_CHARTS_PATH/monitoring/grafana" \
+    --namespace monitoring \
+    --values "$VALUES_FILE" \
+    --values "$HELM_VALUES_PATH/grafana-restored-volume.yaml"
+
+echo "✅ Monitoring Stack Deployed Successfully!"

--- a/scripts/deployments/deploy-nextcloud-drawio.sh
+++ b/scripts/deployments/deploy-nextcloud-drawio.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Load sensitive configuration from .env
+if [ -f ./terraform/.env ]; then
+  source ./terraform/.env
+else
+  echo "Missing .env file. Exiting."
+  exit 1
+fi
+
+# === CONFIG ===
+NS="${NEXTCLOUD_NAMESPACE:-nextcloud}"
+NEXTCLOUD_LABEL="${NEXTCLOUD_LABEL:-app.kubernetes.io/name=nextcloud}"
+
+POD=$(kubectl get pod -n "$NS" -l "$NEXTCLOUD_LABEL" -o jsonpath='{.items[0].metadata.name}')
+
+exec_occ() {
+  kubectl exec -n "$NS" "$POD" -- su -s /bin/bash www-data -c "php occ $*"
+}
+
+wait_for_ready() {
+  local label=$1
+  local appname=$2
+  echo "🔄 Waiting for $appname pod to become Ready..."
+  until kubectl wait --for=condition=ready pod -n "$NS" -l "$label" --timeout=10s 2>/dev/null; do
+    echo "⏳ Still waiting for $appname..."
+    sleep 5
+  done
+}
+
+# === Wait for Nextcloud pod ===
+wait_for_ready "$NEXTCLOUD_LABEL" "Nextcloud"
+
+# === INSTALL & ENABLE draw.io ===
+exec_occ app:install drawio || true
+exec_occ app:enable drawio

--- a/scripts/deployments/deploy-nextcloud-onlyoffice.sh
+++ b/scripts/deployments/deploy-nextcloud-onlyoffice.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# default to "staging" if DEPLOYMENT_MODE is not set
+: "${DEPLOYMENT_MODE:=staging}"
+
+# Determine script dir & load config.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if   [ -f "$SCRIPT_DIR/config.sh" ]; then
+  source "$SCRIPT_DIR/config.sh"
+elif [ -f "$SCRIPT_DIR/../../../scripts/config.sh" ]; then
+  source "$SCRIPT_DIR/../../../scripts/config.sh"
+else
+  echo "Missing config.sh file. Exiting." >&2
+  exit 1
+fi
+
+echo "📡 Deploying OnlyOffice Document Server"
+
+# 1️⃣ Create namespace
+kubectl create namespace nextcloud 2>/dev/null || true
+
+# 2️⃣ Import Secrets & Middlewares
+echo "🔑 Importing OnlyOffice JWT secret..."
+kubectl apply -f "$SECRETS_PATH/onlyoffice-creds-sealed-secret.yaml"
+
+echo "🔑 Importing OnlyOffice Middleware for headers..."
+kubectl apply -f "$MIDDLEWARES_PATH/onlyoffice-secure-headers.yaml"
+
+# 3️⃣ Restore Volumes via Longhorn
+echo "🔐 Restoring OnlyOffice volumes..."
+base/scripts/longhorn-automation.sh restore onlyoffice-files   --wrapper
+base/scripts/longhorn-automation.sh restore onlyoffice-postgres   --wrapper
+echo "✅ OnlyOffice volumes restored!"
+
+# 4️⃣ Choose prod vs. staging
+if [[ "$DEPLOYMENT_MODE" == "prod" ]]; then
+  echo "🚀 Using Production values..."
+  VALUES_FILE="$HELM_VALUES_PATH/prod/onlyoffice/onlyoffice-values.yaml"
+  VOLS_FILE="$HELM_VALUES_PATH/prod/onlyoffice/onlyoffice-volumes-values.yaml"
+  BACKEND_FILE="$HELM_VALUES_PATH/prod/onlyoffice/onlyoffice-backend-values.yaml"
+else
+  echo "⚠️  Using Staging values..."
+  VALUES_FILE="$HELM_VALUES_PATH/staging/onlyoffice/onlyoffice-values.yaml"
+  VOLS_FILE="$HELM_VALUES_PATH/staging/onlyoffice/onlyoffice-volumes-values.yaml"
+  BACKEND_FILE="$HELM_VALUES_PATH/staging/onlyoffice/onlyoffice-backend-values.yaml"
+fi
+
+# 5️⃣ Deploy volumes subchart
+echo "📦 Deploying OnlyOffice-volumes chart..."
+helm dependency update "$HELM_CHARTS_PATH/onlyoffice/volumes"
+helm upgrade --install onlyoffice-volumes "$HELM_CHARTS_PATH/onlyoffice/volumes" \
+  --namespace nextcloud \
+  --values "$VOLS_FILE" \
+  --values "$HELM_VALUES_PATH/onlyoffice-files-restored-volume.yaml" \
+  --values "$HELM_VALUES_PATH/onlyoffice-postgres-restored-volume.yaml" \
+
+# 5️⃣ Deploy backend subchart
+echo "📦 Deploying OnlyOffice-backend chart..."
+helm dependency update "$HELM_CHARTS_PATH/onlyoffice/backend"
+helm upgrade --install onlyoffice-backend "$HELM_CHARTS_PATH/onlyoffice/backend" \
+  --namespace nextcloud \
+  --values "$BACKEND_FILE" \
+
+# 6️⃣ Deploy the Document Server chart
+echo "📦 Deploying OnlyOffice DocumentServer chart..."
+helm dependency update "$HELM_CHARTS_PATH/onlyoffice/app"
+helm upgrade --install onlyoffice "$HELM_CHARTS_PATH/onlyoffice/app" \
+  --namespace nextcloud \
+  --values "$VALUES_FILE"
+echo "✓ OnlyOffice chart deployed"
+
+# 7️⃣ Wire into Nextcloud
+echo "🔧 Configuring Nextcloud to use OnlyOffice..."
+bash base/scripts/deployments/wire-onlyoffice.sh
+echo "✓ Nextcloud configured with OnlyOffice"
+
+# echo "✅ OnlyOffice deployed and wired into Nextcloud!"

--- a/scripts/deployments/wire-onlyoffice.sh
+++ b/scripts/deployments/wire-onlyoffice.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Load sensitive configuration from .env
+if [ -f ./terraform/.env ]; then
+  source ./terraform/.env
+else
+  echo "Missing .env file. Exiting."
+  exit 1
+fi
+
+# === CONFIG ===
+NS="${NEXTCLOUD_NAMESPACE:-nextcloud}"
+NEXTCLOUD_LABEL="${NEXTCLOUD_LABEL:-app.kubernetes.io/name=nextcloud}"
+ONLYOFFICE_LABEL="${ONLYOFFICE_LABEL:-app=docservice}"
+ONLYOFFICE_SECRET="${ONLYOFFICE_SECRET:-onlyoffice-creds}"
+
+PUBLIC_URL="${ONLYOFFICE_PUBLIC_URL:-https://onlyoffice.example.com}"
+INTERNAL_URL="${ONLYOFFICE_INTERNAL_URL:-http://documentserver}"
+STORAGE_URL="${NEXTCLOUD_STORAGE_URL:-http://nextcloud:8080}"
+
+POD=$(kubectl get pod -n "$NS" -l "$NEXTCLOUD_LABEL" -o jsonpath='{.items[0].metadata.name}')
+JWT_SECRET=$(kubectl get secret "$ONLYOFFICE_SECRET" -n "$NS" -o jsonpath='{.data.JWT_SECRET}' | base64 --decode)
+
+exec_occ() {
+  kubectl exec -n "$NS" "$POD" -- su -s /bin/bash www-data -c "php occ $*"
+}
+
+wait_for_ready() {
+  local label=$1
+  local appname=$2
+  echo "🔄 Waiting for $appname pod to become Ready..."
+  until kubectl wait --for=condition=ready pod -n "$NS" -l "$label" --timeout=10s 2>/dev/null; do
+    echo "⏳ Still waiting for $appname..."
+    sleep 5
+  done
+}
+
+wait_for_ready "$NEXTCLOUD_LABEL" "Nextcloud"
+wait_for_ready "$ONLYOFFICE_LABEL" "OnlyOffice"
+
+# === INSTALL ONLYOFFICE APP ===
+exec_occ app:install onlyoffice || true
+exec_occ app:enable onlyoffice
+
+# === APPLY MINIMAL CONFIG ===
+exec_occ config:app:set onlyoffice DocumentServerUrl --value="$PUBLIC_URL"
+exec_occ config:app:set onlyoffice DocumentServerInternalUrl --value="$INTERNAL_URL"
+exec_occ config:app:set onlyoffice StorageUrl --value="$STORAGE_URL"
+exec_occ config:app:set onlyoffice jwt_secret --value="$JWT_SECRET"

--- a/scripts/secrets/generate-grafana-sealed-secrets.sh
+++ b/scripts/secrets/generate-grafana-sealed-secrets.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 🔍 Check for required tools
+required_tools=("tr" "head" "bash")
+for tool in "${required_tools[@]}"; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "❌ Required tool '$tool' is not installed or not in PATH."
+    exit 1
+  fi
+done
+
+# 🧪 Check that the sealed secret generator script exists
+sealed_secret_script="base/scripts/generate-sealed-secret.sh"
+if [[ ! -x "$sealed_secret_script" ]]; then
+  echo "❌ Required script '$sealed_secret_script' not found or not executable."
+  exit 1
+fi
+
+# 🔐 Function to generate a random alphanumeric string of a given length
+generate_random() {
+  local length=$1
+  LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom 2>/dev/null | head -c "$length" || true
+}
+
+# 📁 Define output file
+output_file="./secrets/helm_credentials.txt"
+mkdir -p "$(dirname "$output_file")"
+> "$output_file"
+
+# 🧬 Generate Grafana admin credentials
+admin_user="admin"
+admin_password=$(generate_random 22)
+
+# 🧾 Write credentials into one sealed secret definition
+# Format: <app> <secret-name> key1=value1 key2=value2 …
+echo "monitoring grafana-admin-credentials admin-user=${admin_user} admin-password=${admin_password}" \
+  >> "$output_file"
+
+# 🔁 Convert the generated secret into a SealedSecret
+echo "🔐 Generating sealed secret for Grafana…"
+while IFS= read -r line || [ -n "$line" ]; do
+  [[ "$line" =~ ^#.*$ ]] && continue
+  [[ -z "$line" ]] && continue
+  bash "$sealed_secret_script" $line
+done < "$output_file"
+
+echo
+echo "✅ Grafana sealed secret applied! Now update your Helm values to reference:"
+echo "    admin.existingSecret:      grafana-admin-credentials"
+echo "    admin.existingSecretKey:   admin-password"

--- a/scripts/secrets/generate-nextcloud-sealed-secrets.sh
+++ b/scripts/secrets/generate-nextcloud-sealed-secrets.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 🔍 Check for required tools
+required_tools=("tr" "head" "bash")
+for tool in "${required_tools[@]}"; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "❌ Required tool '$tool' is not installed or not in PATH."
+    exit 1
+  fi
+done
+
+# 🧪 Check that the sealed secret generator script exists
+sealed_secret_script="base/scripts/generate-sealed-secret.sh"
+if [[ ! -x "$sealed_secret_script" ]]; then
+  echo "❌ Required script '$sealed_secret_script' not found or not executable."
+  exit 1
+fi
+
+# 🔐 Function to generate a random alphanumeric string of a given length
+generate_random() {
+  local length=$1
+  LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom 2>/dev/null | head -c "$length" || true
+}
+
+# 📁 Define output file
+output_file="./secrets/helm_credentials.txt"
+mkdir -p "$(dirname "$output_file")"
+> "$output_file"
+
+# 🧬 Generate Nextcloud credentials
+nextcloud_password=$(generate_random 24)
+db_username="nextcloud"
+db_password=$(generate_random 24)
+postgres_password=$(generate_random 24)
+redis_password=$(generate_random 24)
+
+# 🧾 Write credentials into one sealed secret definition
+echo "nextcloud nextcloud-creds username=${db_username} password=${nextcloud_password} db-username=${db_username} db-password=${db_password} postgres-password=${postgres_password} redis-password=${redis_password}" >> "$output_file"
+
+# 🔁 Convert the generated secret into a SealedSecret
+echo "🔐 Generating sealed secret for Nextcloud..."
+while IFS= read -r line || [ -n "$line" ]; do
+  [[ "$line" =~ ^#.*$ ]] && continue
+  [[ -z "$line" ]] && continue
+  bash "$sealed_secret_script" $line
+done < "$output_file"
+
+echo
+echo "✅ Nextcloud sealed secret generated! Update your Helm values to reference:"
+echo "  nextcloud.auth.existingSecret: nextcloud-creds"
+echo "  nextcloud.auth.secretKeys:"
+echo "    username: username"
+echo "    password: password"
+echo "    dbUsername: db-username"
+echo "    dbPassword: db-password"
+echo "    postgresPassword: postgres-password"
+echo "    redisPassword: redis-password"

--- a/scripts/secrets/generate-onlyoffice-sealed-secrets.sh
+++ b/scripts/secrets/generate-onlyoffice-sealed-secrets.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 🔍 Check for required tools
+required_tools=("tr" "head" "bash" "htpasswd")
+for tool in "${required_tools[@]}"; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "❌ Required tool '$tool' is not installed or not in PATH."
+    exit 1
+  fi
+done
+
+# 🧪 Check that the sealed secret generator script exists
+sealed_secret_script="base/scripts/generate-sealed-secret.sh"
+if [[ ! -x "$sealed_secret_script" ]]; then
+  echo "❌ Required script '$sealed_secret_script' not found or not executable."
+  exit 1
+fi
+
+# 🔐 Function to generate a random alphanumeric string of a given length
+generate_random() {
+  local length=$1
+  LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom 2>/dev/null | head -c "$length" || true
+}
+
+# 📁 Define output file
+output_file="./secrets/helm_credentials.txt"
+mkdir -p "$(dirname "$output_file")"
+> "$output_file"
+
+# 🧬 Generate OnlyOffice credentials
+postgres_password=$(generate_random 22)
+redis_password=$(generate_random 22)
+rabbitmq_password=$(generate_random 22)
+erlang_cookie=$(generate_random 20)
+jwt_secret=$(generate_random 44)
+
+amqp_uri="amqp://onlyoffice:${rabbitmq_password}@onlyoffice-backend-rabbitmq:5672/?frameMax=0"
+
+# 🧾 Write credentials into one sealed secret definition
+echo "nextcloud onlyoffice-creds postgres-password=${postgres_password} redis-password=${redis_password} erlang-cookie=${erlang_cookie} rabbitmq-password=${rabbitmq_password} amqp-uri='${amqp_uri}' JWT_ENABLED=true JWT_HEADER=Authorization JWT_IN_BODY=false JWT_SECRET=${jwt_secret}" >> "$output_file"
+
+# 🔁 Convert the generated secret into a SealedSecret
+echo "🔐 Generating sealed secret for OnlyOffice..."
+while IFS= read -r line || [ -n "$line" ]; do
+  [[ "$line" =~ ^#.*$ ]] && continue
+  [[ -z "$line" ]] && continue
+  bash "$sealed_secret_script" $line
+done < "$output_file"
+
+echo
+echo "✅ OnlyOffice sealed secrets generated! Update your Helm values to reference:"
+echo "  postgres:  existingSecret: onlyoffice-creds  -> postgres-password"
+echo "  redis:     existingSecret: onlyoffice-creds  -> redis-password"
+echo "  rabbitmq:  existingPasswordSecret: onlyoffice-creds -> rabbitmq-password"
+echo "             existingErlangSecret: onlyoffice-creds -> erlang-cookie"
+echo "  onlyoffice.jwt: existingSecret: onlyoffice-creds -> JWT_SECRET"
+echo "  onlyoffice.env: amqp-uri key via onlyoffice-creds"

--- a/tests/xslt-transform/README.md
+++ b/tests/xslt-transform/README.md
@@ -1,0 +1,29 @@
+# XSLT Transform Smoke Test
+
+This directory lets you rapidly verify changes to `config/memory_backing.xslt` without touching your production Terraform stack.
+
+## Prerequisites
+
+- Terraform & the `terraform-provider-libvirt` plugin installed  
+- Local `virsh` client (e.g. via Homebrew: `brew install libvirt`)  
+- SSH access to your libvirt host at `192.168.14.231` as user `atlasmalt`
+
+## Usage
+
+From this folder:
+
+```bash
+# 1) Initialize the test
+terraform init
+
+# 2) Apply the tiny VM
+terraform apply -var-file=../../../terraform/terraform.tfvars --auto-approve
+
+# 3) Dump the transformed XML locally:
+virsh -c 'qemu+ssh://atlasmalt@192.168.14.231/system?no_verify=1' \
+     dumpxml test-transform > after.xml
+
+# 4) Inspect `after.xml` for your <cpu .../> and <memoryBacking> sections
+
+# 5) Tear it down
+terraform destroy -var-file=../../../terraform/terraform.tfvars --auto-approve

--- a/tests/xslt-transform/after.xml
+++ b/tests/xslt-transform/after.xml
@@ -1,0 +1,105 @@
+<domain type='kvm' id='1'>
+  <name>test-transform</name>
+  <uuid>80565eb5-26a0-4299-874d-cbc20856ef56</uuid>
+  <memory unit='KiB'>65536</memory>
+  <currentMemory unit='KiB'>65536</currentMemory>
+  <memoryBacking>
+    <source type='memfd'/>
+    <access mode='shared'/>
+  </memoryBacking>
+  <vcpu placement='static'>1</vcpu>
+  <resource>
+    <partition>/machine</partition>
+  </resource>
+  <os>
+    <type arch='x86_64' machine='pc-i440fx-8.2'>hvm</type>
+    <boot dev='hd'/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <cpu mode='host-passthrough' check='none' migratable='on'/>
+  <clock offset='utc'/>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type='volume' device='disk'>
+      <driver name='qemu' type='qcow2'/>
+      <source pool='test-pool' volume='tiny.qcow2' index='1'/>
+      <backingStore/>
+      <target dev='vda' bus='virtio'/>
+      <alias name='virtio-disk0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/>
+    </disk>
+    <controller type='usb' index='0' model='piix3-uhci'>
+      <alias name='usb'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x2'/>
+    </controller>
+    <controller type='pci' index='0' model='pci-root'>
+      <alias name='pci.0'/>
+    </controller>
+    <controller type='virtio-serial' index='0'>
+      <alias name='virtio-serial0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
+    </controller>
+    <interface type='network'>
+      <mac address='52:54:00:7e:6f:fe'/>
+      <source network='default' portid='08c05303-1767-43df-a291-177d4a1e7a4f' bridge='virbr0'/>
+      <target dev='vnet0'/>
+      <model type='virtio'/>
+      <alias name='net0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
+    </interface>
+    <serial type='pty'>
+      <source path='/dev/pts/1'/>
+      <target type='isa-serial' port='0'>
+        <model name='isa-serial'/>
+      </target>
+      <alias name='serial0'/>
+    </serial>
+    <console type='pty' tty='/dev/pts/1'>
+      <source path='/dev/pts/1'/>
+      <target type='serial' port='0'/>
+      <alias name='serial0'/>
+    </console>
+    <channel type='unix'>
+      <source mode='bind' path='/run/libvirt/qemu/channel/1-test-transform/org.qemu.guest_agent.0'/>
+      <target type='virtio' name='org.qemu.guest_agent.0' state='disconnected'/>
+      <alias name='channel0'/>
+      <address type='virtio-serial' controller='0' bus='0' port='1'/>
+    </channel>
+    <input type='mouse' bus='ps2'>
+      <alias name='input0'/>
+    </input>
+    <input type='keyboard' bus='ps2'>
+      <alias name='input1'/>
+    </input>
+    <graphics type='spice'>
+      <listen type='none'/>
+    </graphics>
+    <audio id='1' type='spice'/>
+    <video>
+      <model type='cirrus' vram='16384' heads='1' primary='yes'/>
+      <alias name='video0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
+    </video>
+    <memballoon model='virtio'>
+      <alias name='balloon0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
+    </memballoon>
+    <rng model='virtio'>
+      <backend model='random'>/dev/urandom</backend>
+      <alias name='rng0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x0'/>
+    </rng>
+  </devices>
+  <seclabel type='dynamic' model='dac' relabel='yes'>
+    <label>+64055:+994</label>
+    <imagelabel>+64055:+994</imagelabel>
+  </seclabel>
+</domain>
+

--- a/tests/xslt-transform/config/memory_backing.xslt
+++ b/tests/xslt-transform/config/memory_backing.xslt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet 
+    version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:output method="xml" indent="yes"/>
+
+  <!-- 1) Drop any existing <cpu> definitions entirely -->
+  <xsl:template match="cpu"/>
+
+  <!-- 2) Root template: copy the <domain> element and everything beneath… -->
+  <xsl:template match="/domain">
+    <xsl:copy>
+      <!-- …preserve ALL child nodes & attributes verbatim -->
+      <xsl:apply-templates select="@*|node()"/>
+
+      <!-- 3) THEN append your passthrough CPU -->
+      <cpu mode="host-passthrough" check="none" migratable="on"/>
+
+      <!-- 4) AND append your memoryBacking block -->
+      <memoryBacking>
+        <source type="memfd"/>
+        <access mode="shared"/>
+      </memoryBacking>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- 5) Identity template for everything else -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/tests/xslt-transform/provider.tf
+++ b/tests/xslt-transform/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    libvirt = {
+      source  = "dmacvicar/libvirt"
+      version = "0.8.1"
+    }
+  }
+}
+
+provider "libvirt" {
+  uri = "qemu+ssh://${var.libvirt_user}@${var.host_ip}/system?no_verify=1"
+}

--- a/tests/xslt-transform/test.tf
+++ b/tests/xslt-transform/test.tf
@@ -1,0 +1,60 @@
+# ────────────────────────────────────────────────────────────
+# 1) Create a quick-and-dirty pool so we have somewhere to put disks
+# ────────────────────────────────────────────────────────────
+resource "libvirt_pool" "test_pool" {
+  name = "test-pool"
+  type = "dir"
+
+  target {
+    # this directory almost always exists on a standard libvirt host
+    path = "/var/lib/libvirt/images"
+  }
+}
+
+# ────────────────────────────────────────────────────────────
+# 2) A tiny 16 MiB QCOW2 volume
+# ────────────────────────────────────────────────────────────
+resource "libvirt_volume" "tiny" {
+  name   = "tiny.qcow2"
+  pool   = libvirt_pool.test_pool.name
+  format = "qcow2"
+  size   = 16 * 1024 * 1024   # 16 MiB
+}
+
+# ────────────────────────────────────────────────────────────
+# 3) Minimal VM that applies your XSLT and does nothing else
+# ────────────────────────────────────────────────────────────
+resource "libvirt_domain" "test" {
+  name   = "test-transform"
+  memory = 64
+  vcpu   = 1
+
+  # attach the tiny disk
+  disk {
+    volume_id = libvirt_volume.tiny.id
+  }
+
+  # default libvirt network ‘default’ — adjust if yours is named differently
+  network_interface {
+    network_name   = "default"
+    wait_for_lease = false
+  }
+
+  # no display, just a console
+  graphics {
+    type        = "spice"
+    listen_type = "none"
+  }
+  console {
+    type        = "pty"
+    target_type = "serial"
+    target_port = "0"
+  }
+
+  # apply your transform
+  xml {
+    xslt = file("${path.module}/config/memory_backing.xslt")
+  }
+
+  autostart = false
+}

--- a/tests/xslt-transform/variables.tf
+++ b/tests/xslt-transform/variables.tf
@@ -1,0 +1,10 @@
+
+variable "libvirt_user" {
+  type        = string
+  description = "username used for logging into libvirtd with SSH"
+}
+
+variable "host_ip" {
+  type        = string
+  description = "IP address of the Host"
+}


### PR DESCRIPTION
---

### 🚀 Deploy Nextcloud with OnlyOffice, Draw\.io + Script Refactors

This PR delivers a complete deployment setup for **Nextcloud**, including **OnlyOffice** and **draw\.io** integration, along with script refactoring for better structure and maintainability.

#### ✅ Key Changes

* **📦 Nextcloud App Integrations**

  * New deployment scripts for OnlyOffice (`deploy-nextcloud-onlyoffice.sh`) and Draw\.io (`deploy-nextcloud-drawio.sh`)
  * Added `wire-onlyoffice.sh` to auto-configure OnlyOffice using `occ` and Kubernetes secrets

* **🧩 OnlyOffice Modular Helm Charts**

  * Subcharts for `app`, `backend` (PostgreSQL, Redis, RabbitMQ), and `volumes`
  * Supports Longhorn volume provisioning via Helm values

* **🔐 Sealed Secrets Automation**

  * Added sealed secret generation scripts for:

    * OnlyOffice
    * Nextcloud
    * Grafana (monitoring)

* **📁 Script Refactoring**

  * Moved `deploy-longhorn.sh` and `deploy-monitoring.sh` to `scripts/deployments/` for cleaner structure
  * No logic changes — just directory cleanup

* **🧪 XSLT Transform Test Harness**

  * Adds a Terraform-based test harness under `tests/xslt-transform/` to validate domain XML transforms locally

* **📚 Docs**

  * Added `nextcloud-debugging-commands.md` for OnlyOffice integration validation

---