### PR TITLE
Added auto mode for nuke script.  Using base-image outside of terraform

### DIFF
--- a/terraform/scripts/nuke-deploy-cluster.sh
+++ b/terraform/scripts/nuke-deploy-cluster.sh
@@ -48,19 +48,25 @@ export CERT_ISSUER
 
 echo "🔄 Nuke and Deploy K3s Cluster"
 
-echo "⚠️ WARNING: This will destroy and redeploy your entire cluster!"
-read -p "Are you sure? (yes/no): " confirm
-if [[ "$confirm" != "yes" ]]; then
-    echo "❌ Operation cancelled."
-    exit 1
-fi
+OVERRIDE=${2:-}
 
-echo "⚠️ WARNING: Would you like to first create a backup of the persistent volumes?"
-read -p "Create Backups? (yes/no): " confirm
-if [[ "$confirm" == "yes" ]]; then
-    echo "🚀 Backing up volumes on the cluster..."
-    base/scripts/longhorn-batch.sh
-    echo "✅ All volumes backed up."
+if [[ "$OVERRIDE" != "--yes" ]]; then
+  echo "⚠️ WARNING: This will destroy and redeploy your entire cluster!"
+  read -p "Are you sure? (yes/no): " confirm
+  if [[ "$confirm" != "yes" ]]; then
+      echo "❌ Operation cancelled."
+      exit 1
+  fi
+
+  echo "⚠️ WARNING: Would you like to first create a backup of the persistent volumes?"
+  read -p "Create Backups? (yes/no): " confirm
+  if [[ "$confirm" == "yes" ]]; then
+      echo "🚀 Backing up volumes on the cluster..."
+      base/scripts/longhorn-batch.sh
+      echo "✅ All volumes backed up."
+  fi
+else
+  echo "✅ Override flag detected — skipping prompts and backup step."
 fi
 
 echo "🔥 Destroying existing cluster..."


### PR DESCRIPTION
---

### 🧹 Tech Debt Cleanup: Externalize Base Image + Add Auto Mode to Nuke Script

This PR includes two key improvements:

1. **Base Image Handling**

   * The base Ubuntu image is now managed *outside* of Terraform, improving control and predictability over VM image usage.
   * Replaced the dynamic Terraform-managed `base_image` resource with a direct reference to a pre-uncompressed image file in the `base-image-pool`.
   * This simplifies Terraform state and avoids unnecessary downloads or regenerations of the image.

2. **Improved `nuke-deploy-cluster.sh` UX**

   * Added a `--yes` flag to allow non-interactive execution (ideal for CI or automation).
   * Backup prompt is now conditional and skippable via the override flag.
   * Script behavior is safer and more flexible for both manual and automated workflows.

---